### PR TITLE
Fix compiler crash building i386 [#7]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "NativeMarkKit",
     platforms: [
         .macOS(.v10_11),
-        .iOS(.v9),
-        .tvOS(.v9)
+        .iOS(.v11),
+        .tvOS(.v11)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/NativeMarkKit/render/URLOpener.swift
+++ b/Sources/NativeMarkKit/render/URLOpener.swift
@@ -10,7 +10,7 @@ public struct URLOpener {
         #if canImport(AppKit)
         NSWorkspace.shared.open(url)
         #elseif canImport(UIKit)
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
         #else
         #error("Unsupported platform")
         #endif


### PR DESCRIPTION
# Problem

#7 

When building release configuration of certain iOS apps, Xcode will ask for i386 simulator builds for NativeMarkKit. This happens if the Xcode project doesn't use these old versions of iOS. The problem is with Xcode 12.5 there is a crashing compiler bug when building NativeMarkKit for i386.

# Solution

Bump the minimum iOS and tvOS versions to 11. At this point Xcode 12.5 no longer attempts to build any i386 Simulators and we are spared compiler crashes.