### PR TITLE
Replaced the deprecated `openURL:` method with its new counter part for iOS10+

### DIFF
--- a/Sources/NativeMarkKit/render/URLOpener.swift
+++ b/Sources/NativeMarkKit/render/URLOpener.swift
@@ -10,7 +10,7 @@ public struct URLOpener {
         #if canImport(AppKit)
         NSWorkspace.shared.open(url)
         #elseif canImport(UIKit)
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
         #else
         #error("Unsupported platform")
         #endif


### PR DESCRIPTION
https://github.com/andyfinnell/NativeMarkKit/issues/7

# Problem

An app, integrating the package wouldn't build and would error out with a compiler crash if the `openURL:` method from iOS 10 was used.

# Solution

Replaced `openURL:`  with the newer `open(url:options:completionHandler:)`