### PR TITLE
Fix large image rendering bugs 

### DIFF
--- a/Sources/NativeMarkKit/render/NativeMarkLabel+AppKit.swift
+++ b/Sources/NativeMarkKit/render/NativeMarkLabel+AppKit.swift
@@ -115,7 +115,10 @@ final class URLAcccessibilityElement: NSAccessibilityElement {
 
 extension NativeMarkLabel: AbstractViewDelegate {
     func abstractViewDidInvalidateRect(_ rect: CGRect) {
+        invalidateIntrinsicContentSize()
         setNeedsDisplay(rect)
+        updateAccessibility()
+        onIntrinsicSizeInvalidated?()
     }
 }
 #endif

--- a/Sources/NativeMarkKit/render/NativeMarkLabel+UIKit.swift
+++ b/Sources/NativeMarkKit/render/NativeMarkLabel+UIKit.swift
@@ -114,7 +114,10 @@ private extension NativeMarkLabel {
 
 extension NativeMarkLabel: AbstractViewDelegate {
     func abstractViewDidInvalidateRect(_ rect: CGRect) {
+        invalidateIntrinsicContentSize()
         setNeedsDisplay(rect)
+        updateAccessibility()
+        onIntrinsicSizeInvalidated?()
     }
 }
 

--- a/Sources/NativeMarkKit/render/NativeMarkLayoutManager.swift
+++ b/Sources/NativeMarkKit/render/NativeMarkLayoutManager.swift
@@ -109,6 +109,7 @@ extension NativeMarkLayoutManager {
         layoutManager.invalidateDisplay(forCharacterRange: characterRange)
         
         let glyphRange = layoutManager.glyphRange(forCharacterRange: characterRange, actualCharacterRange: nil)
+        layoutManager.ensureLayout(forGlyphRange: glyphRange)
         
         if let container = layoutManager.textContainer(forGlyphAt: glyphRange.location, effectiveRange: nil),
             let wrappedContainer = textContainers.first(where: { $0.container === container }) {

--- a/Sources/NativeMarkKit/render/NativeMarkLayoutManager.swift
+++ b/Sources/NativeMarkKit/render/NativeMarkLayoutManager.swift
@@ -105,16 +105,24 @@ public final class NativeMarkLayoutManager: NSObject {
 
 extension NativeMarkLayoutManager {
     func invalidateImage(in characterRange: NSRange) {
-        layoutManager.invalidateLayout(forCharacterRange: characterRange, actualCharacterRange: nil)
-        layoutManager.invalidateDisplay(forCharacterRange: characterRange)
+        var actualRange = NSRange()
+        layoutManager.invalidateLayout(forCharacterRange: characterRange, actualCharacterRange: &actualRange)
+        layoutManager.invalidateDisplay(forCharacterRange: actualRange)
         
-        let glyphRange = layoutManager.glyphRange(forCharacterRange: characterRange, actualCharacterRange: nil)
-        layoutManager.ensureLayout(forGlyphRange: glyphRange)
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: actualRange, actualCharacterRange: nil)
         
         if let container = layoutManager.textContainer(forGlyphAt: glyphRange.location, effectiveRange: nil),
             let wrappedContainer = textContainers.first(where: { $0.container === container }) {
             let bounds = layoutManager.boundingRect(forGlyphRange: glyphRange, in: container)
             delegate?.layoutManager(self, invalidateFrame: bounds, inContainer: wrappedContainer)
+        } else {
+            // In this case, the image is big enough to force things out of the container
+            //  Brute force the updates
+            for wrappedContainer in textContainers {
+                let glyphRange = layoutManager.glyphRange(for: wrappedContainer.container)
+                let bounds = layoutManager.boundingRect(forGlyphRange: glyphRange, in: wrappedContainer.container)
+                delegate?.layoutManager(self, invalidateFrame: bounds, inContainer: wrappedContainer)
+            }
         }
     }
         


### PR DESCRIPTION
# Problem

On macOS in particular, large image attachments were not rendering at all or not rendering until the window was resizes. This was because of a couple of issues:

1. The full affected range was not being invalidated
1. If the size of the image forced it outside the container, no view-level invalidation happened
1. The view didn't invalidate its intrinsic content size when an image was loaded

# Solution

Capture and use the full affected character range, provide a brute force invalidation fallback of the image is forced outside the container, and invalid the intrinsic size on image load.