### PR TITLE
Allow custom image sizing

### DIFF
--- a/Documentation/Images.md
+++ b/Documentation/Images.md
@@ -21,3 +21,31 @@ StyleSheet.default.mutate(imageLoader: MyImageLoader())
 ```
 
 The `ImageLoader` protocol only requires one method. The `completion` method must be invoked, even if the loading fails. It also must be invoked on the main thread.
+
+# Scaling images
+
+By default, NativeMarkKit will not resize the images it downloads, but render them at their natural size. This isn't always desirable, so nativeMarkKit provides a customization point to allow whatever kind of scaling the app wants.
+
+The image sizing behavior is attached to the `StyleSheet`, and can be overridden there. To provide a custom image sizer, the app needs to implement the `ImageSizer` protocol (or use a built-in implementation), then mutate any `StyleSheet`s it wants to use its custom image sizer.
+
+```Swift
+import NativeMarkKit
+
+struct MyImageSizer: ImageSizer {
+    func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize {
+        // Implement whatever scaling you wish here. Return the new image size
+    }
+}
+
+// In app startup have our custom loader be used by default
+StyleSheet.default.mutate(imageSizer: MyImageSizer())
+```
+
+## Built-in image sizers
+
+NativeMarkKit provides a few `ImageSizer`s out of the box:
+
+- `AspectScaleDownByWidth`: This image sizer will scale the image down to fit the line width, preserving the aspect ratio
+- `AspectScaleDownByHeight`: This image sizer will scale the image down to the fit the line height, preserving the aspect ration of the image
+- `DefaultImageSizer`: This image sizer does nothing, and passes through the natural image size
+

--- a/Sources/NativeMarkKit/render/ImageTextAttachment.swift
+++ b/Sources/NativeMarkKit/render/ImageTextAttachment.swift
@@ -7,6 +7,7 @@ import UIKit
 
 protocol ImageTextAttachmentDelegate: AnyObject {
     func imageTextAttachmentLoadImage(_ urlString: String, completion: @escaping (NativeImage?) -> Void)
+    func imageTextAttachmentResize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize
 }
 
 protocol ImageTextAttachmentLayoutDelegate: AnyObject {
@@ -45,7 +46,11 @@ final class ImageTextAttachment: NativeTextAttachment {
     
     override func lineFragment(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect) -> CGRect {
         if let image = loadImage() {
-            return CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+            if let resized = delegate?.imageTextAttachmentResize(imageUrl, image: image, lineFragment: lineFrag) {
+                return CGRect(origin: .zero, size: resized)
+            } else {
+                return CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+            }
         } else {
             return CGRect(x: 0, y: 0, width: lineFrag.height, height: lineFrag.height)
         }

--- a/Sources/NativeMarkKit/style/AspectScaleDownByHeight.swift
+++ b/Sources/NativeMarkKit/style/AspectScaleDownByHeight.swift
@@ -1,4 +1,11 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#else
+#error("Unsupported platform")
+#endif
 
 public struct AspectScaleDownByHeight: ImageSizer {
     public init() {}

--- a/Sources/NativeMarkKit/style/AspectScaleDownByHeight.swift
+++ b/Sources/NativeMarkKit/style/AspectScaleDownByHeight.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct AspectScaleDownByHeight: ImageSizer {
+    public init() {}
+    
+    public func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize {
+        let aspectRatio = image.size.height / image.size.width
+        let height = min(lineFragment.height, image.size.height)
+        let width = height / aspectRatio
+
+        return CGSize(width: width, height: height)
+    }
+}

--- a/Sources/NativeMarkKit/style/AspectScaleDownByWidth.swift
+++ b/Sources/NativeMarkKit/style/AspectScaleDownByWidth.swift
@@ -1,4 +1,11 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#else
+#error("Unsupported platform")
+#endif
 
 public struct AspectScaleDownByWidth: ImageSizer {
     public init() {}

--- a/Sources/NativeMarkKit/style/AspectScaleDownByWidth.swift
+++ b/Sources/NativeMarkKit/style/AspectScaleDownByWidth.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct AspectScaleDownByWidth: ImageSizer {
+    public init() {}
+    
+    public func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize {
+        let aspectRatio = image.size.width / image.size.height
+        let width = min(lineFragment.width, image.size.width)
+        let height = width / aspectRatio
+
+        return CGSize(width: width, height: height)
+    }
+}

--- a/Sources/NativeMarkKit/style/DefaultImageSizer.swift
+++ b/Sources/NativeMarkKit/style/DefaultImageSizer.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct DefaultImageSizer: ImageSizer {
+    public init() {}
+    
+    public func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize {
+        image.size
+    }
+}

--- a/Sources/NativeMarkKit/style/DefaultImageSizer.swift
+++ b/Sources/NativeMarkKit/style/DefaultImageSizer.swift
@@ -1,4 +1,11 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#else
+#error("Unsupported platform")
+#endif
 
 public struct DefaultImageSizer: ImageSizer {
     public init() {}

--- a/Sources/NativeMarkKit/style/ImageSizer.swift
+++ b/Sources/NativeMarkKit/style/ImageSizer.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ImageSizer {
+    func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize
+}

--- a/Sources/NativeMarkKit/style/ImageSizer.swift
+++ b/Sources/NativeMarkKit/style/ImageSizer.swift
@@ -1,4 +1,11 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#else
+#error("Unsupported platform")
+#endif
 
 public protocol ImageSizer {
     func imageSize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize

--- a/Sources/NativeMarkKit/style/StyleSheet.swift
+++ b/Sources/NativeMarkKit/style/StyleSheet.swift
@@ -1,4 +1,11 @@
 import Foundation
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#else
+#error("Unsupported platform")
+#endif
 
 public final class StyleSheet {
     private var blockStyles: [BlockStyleSelector: [BlockStyle]]

--- a/Sources/NativeMarkKit/style/StyleSheet.swift
+++ b/Sources/NativeMarkKit/style/StyleSheet.swift
@@ -4,11 +4,16 @@ public final class StyleSheet {
     private var blockStyles: [BlockStyleSelector: [BlockStyle]]
     private var inlineStyles: [InlineStyleSelector: [InlineStyle]]
     private var imageLoader: ImageLoader
+    private var imageSizer: ImageSizer
     
-    public init(_ blockStyles: [BlockStyleSelector: [BlockStyle]], _ inlineStyles: [InlineStyleSelector: [InlineStyle]], imageLoader: ImageLoader = DefaultImageLoader()) {
+    public init(_ blockStyles: [BlockStyleSelector: [BlockStyle]],
+                _ inlineStyles: [InlineStyleSelector: [InlineStyle]],
+                imageLoader: ImageLoader = DefaultImageLoader(),
+                imageSizer: ImageSizer = DefaultImageSizer()) {
         self.blockStyles = blockStyles
         self.inlineStyles = inlineStyles
         self.imageLoader = imageLoader
+        self.imageSizer = imageSizer
     }
     
     func styles(for blockSelector: BlockStyleSelector) -> [BlockStyle] {
@@ -23,7 +28,10 @@ public final class StyleSheet {
         StyleSheet(blockStyles, inlineStyles, imageLoader: imageLoader)
     }
     
-    public func mutate(block overrideBlockStyles: [BlockStyleSelector: [BlockStyle]] = [:], inline overrideInlineStyles: [InlineStyleSelector: [InlineStyle]] = [:], imageLoader: ImageLoader? = nil) -> StyleSheet {
+    public func mutate(block overrideBlockStyles: [BlockStyleSelector: [BlockStyle]] = [:],
+                       inline overrideInlineStyles: [InlineStyleSelector: [InlineStyle]] = [:],
+                       imageLoader: ImageLoader? = nil,
+                       imageSizer: ImageSizer? = nil) -> StyleSheet {
         for (blockSelector, blockStylesForSelector) in overrideBlockStyles {
             let existingStyles = blockStyles[blockSelector] ?? []
             blockStyles[blockSelector] = existingStyles + blockStylesForSelector
@@ -36,6 +44,10 @@ public final class StyleSheet {
         
         if let imageLoader = imageLoader {
             self.imageLoader = imageLoader
+        }
+        
+        if let imageSizer = imageSizer {
+            self.imageSizer = imageSizer
         }
         
         return self
@@ -130,6 +142,10 @@ public extension StyleSheet {
 }
 
 extension StyleSheet: ImageTextAttachmentDelegate {
+    func imageTextAttachmentResize(_ urlString: String?, image: NativeImage, lineFragment: CGRect) -> CGSize {
+        imageSizer.imageSize(urlString, image: image, lineFragment: lineFragment)
+    }
+    
     func imageTextAttachmentLoadImage(_ urlString: String, completion: @escaping (NativeImage?) -> Void) {
         imageLoader.loadImage(urlString, completion: completion)
     }


### PR DESCRIPTION
# Problem

Right now, NativeMarkKit only renders images at their natural sizes. However, this isn't always what the app wants.

For example, the common use case is to wrap lines at the width of the container. In that case, we don't want the image to be any larger than the line width. If it is, then part of the image is unviewable.

There are other, less common use cases, such as rendering custom image-based emoji, where we want to scale those down to the line height.

# Solution

Implement the `ImageSizer` protocol that abstracts out image scaling, and provide some default scalers.

Provide a few `ImageSizer`s out of the box:

- `AspectScaleDownByWidth`: This image sizer will scale the image down to fit the line width, preserving the aspect ratio
- `AspectScaleDownByHeight`: This image sizer will scale the image down to the fit the line height, preserving the aspect ration of the image
- `DefaultImageSizer`: This image sizer does nothing, and passes through the natural image size. This is the default if you don't change anything.

Apps can also create their own implementation of `ImageSizer`.

To specify a new ImageSizer, call `styleSheet.mutate(imageSizer: MyImageSizer())`, where `styleSheet` is the style sheet to mutate.