### PR TITLE
Support transparent background for NativeMarkText [#17]

### DIFF
--- a/Sources/NativeMarkKit/render/NativeMarkLabel+UIKit.swift
+++ b/Sources/NativeMarkKit/render/NativeMarkLabel+UIKit.swift
@@ -30,13 +30,20 @@ public final class NativeMarkLabel: UIControl {
     public init(nativeMark: String, styleSheet: StyleSheet = .default) {
         abstractView = AbstractView(nativeMark: nativeMark, styleSheet: styleSheet)
         super.init(frame: .zero)
+        if styleSheet.backgroundColor() == nil {
+            backgroundColor = .clear
+        }
         abstractView.delegate = self
         updateAccessibility()
     }
     
     public required init?(coder: NSCoder) {
-        abstractView = AbstractView(nativeMark: "", styleSheet: .default)
+        let styleSheet = StyleSheet.default
+        abstractView = AbstractView(nativeMark: "", styleSheet: styleSheet)
         super.init(frame: .zero)
+        if styleSheet.backgroundColor() == nil {
+            backgroundColor = .clear
+        }
         abstractView.delegate = self
         updateAccessibility()
     }
@@ -118,6 +125,14 @@ extension NativeMarkLabel: AbstractViewDelegate {
         setNeedsDisplay(rect)
         updateAccessibility()
         onIntrinsicSizeInvalidated?()
+    }
+}
+
+private extension StyleSheet {
+    func backgroundColor() -> NativeColor? {
+        var attributes = [NSAttributedString.Key: Any]()
+        styles(for: .document).updateAttributes(&attributes)
+        return attributes[.backgroundColor] as? NativeColor
     }
 }
 

--- a/Sources/NativeMarkKit/style/BlockStyle.swift
+++ b/Sources/NativeMarkKit/style/BlockStyle.swift
@@ -33,7 +33,7 @@ public extension BlockStyle {
         .inlineStyle(.textStyle(value))
     }
         
-    static func backgroundColor(_ value: NativeColor) -> BlockStyle {
+    static func backgroundColor(_ value: NativeColor?) -> BlockStyle {
         .inlineStyle(.backgroundColor(value))
     }
     

--- a/Sources/NativeMarkKit/style/InlineStyle.swift
+++ b/Sources/NativeMarkKit/style/InlineStyle.swift
@@ -10,7 +10,7 @@ import UIKit
 public enum InlineStyle {
     case textColor(NativeColor)
     case textStyle(TextStyle)
-    case backgroundColor(NativeColor)
+    case backgroundColor(NativeColor?)
     case kerning(Length)
     case strikethrough(NSUnderlineStyle, color: NativeColor? = nil)
     case underline(NSUnderlineStyle, color: NativeColor? = nil)


### PR DESCRIPTION
# Problem

It is not currently possible to set the background of a `NativeMarkText` or `NativeMarkLabel` to be completely transparent.

# Solution

First, allow the `.backgroundColor` to take an optional `NativeColor`. This means a user can specify:

```Swift
.document: [
     .backgroundColor(nil)
]
```
to indicate they don't want a background color. This actually fixes it for macOS (i.e. AppKit).

However, UIKit is a special case. For it to work, the `backgroundColor` of the `UIView` _also_ has to be set to `UIColor.clear` otherwise the background still ends up solid black. To fix this, add special code to pull the document's background color and check if its `nil`. If it is `nil`, set `backgroundColor = .clear`.